### PR TITLE
added test for successful use of generate_path in test_utils

### DIFF
--- a/sami2py/tests/test_utils.py
+++ b/sami2py/tests/test_utils.py
@@ -20,6 +20,12 @@ class TestUtils():
         """Runs before every method to create a clean testing setup."""
         sami2py.archive_dir = 'test'
 
+    def test_successful_path_generation(self):
+        """Tests generation of a path that is successful"""
+        out_path = sami2py.utils.generate_path(tag='test', lon=0, year=2012,
+                                               day=277, test=True)
+        assert out_path == sami2py.test_data_dir + '/test/lon000/2012_277/'
+
     @raises(NameError)
     def test_generate_path_w_blank_archive_dir(self):
         """Tests generation of a path without archive_dir set"""


### PR DESCRIPTION
small update to test_utils that includes a test that the output from an exception free use of generate_path produces the expected output. Related to issue #17 