### PR TITLE
use setup.cfg for metadata, build sami2py.x without Make

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 132
+exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.mypy_cache/
+
 # Fortran modules and executables
 *.o
 *.x

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+ignore_missing_imports = True
+strict_optional = False
+allow_redefinition = True
+show_error_context = False
+show_column_numbers = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,37 @@
+[metadata]
+name = sami2py
+version = 0.1.2
+url = https://github.com/jklenzing/sami2py
+author = Jeff Klenzing
+author_email = jeffrey.klenzing@nasa.gov
+description = Generate, read, and plot SAMI2 model runs
+keywords =
+  SAMI2
+  ionosphere
+classifiers =
+  Development Status :: 3 - Alpha
+  Topic :: Scientific/Engineering :: Physics
+  Intended Audience :: Science/Research
+  License :: BSD
+  Natural Language :: English
+  Programming Language :: Python :: 2.7
+  Programming Language :: Python :: 3.4
+  Programming Language :: Python :: 3.5
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+  Operating System :: OS Independent
+license_file = License.md
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+python_requires = >= 2.7
+setup_requires =
+  setuptools >= 38.6
+  pip >= 10
+include_package_data = True
+zip_safe = False
+packages = find:
+install_requires =
+  numpy
+scripts =

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,11 @@
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
 
+from __future__ import print_function
 import sys
 from os import path, mkdir
-from setuptools import setup, find_packages
-
-
-# Define a read function for using README for long_description
-def read(fname):
-    return open(path.join(path.dirname(__file__), fname)).read()
-
+from setuptools import setup
+import subprocess
 
 # generate path for fortran model files
 here = path.abspath(path.dirname(__file__))
@@ -20,9 +16,22 @@ fortran_path = path.join(here, 'sami2py', 'fortran')
 test_data_path = path.join(here, 'sami2py', 'tests', 'test_data')
 file_path = path.join(sys.prefix, '.sami2py')
 
-if not path.isfile(fortran_path + '/sami2py.x'):
-    print('\n'.join(['\nYou will need to compile the fortran files.  Try',
-                     '$  make -C sami2py/fortran compile\n']))
+# %% build
+
+
+if not path.isfile(path.join(fortran_path, 'sami2py.x')):
+    try:  # py27 does not have shutil.which()
+        cmd = ['gfortran', '-fno-range-check', '-fno-automatic', '-ffixed-line-length-none',
+               '-o', 'sami2py.x']
+        src = ['nrlmsise00_modified.f', 'grid-1.00.f', 'sami2py-1.00.f', 'hwm93.f', 'hwm07e_modified.f90',
+               'apexcord.f90', 'hwm14.f90']
+        subprocess.call(cmd + src, cwd=fortran_path)
+    except OSError:
+        pass
+
+if not path.isfile(path.join(fortran_path, 'sami2py.x')):
+    print('\nYou will need to compile the fortran files.  Try\n'
+          '$  make -C sami2py/fortran compile\n', file=sys.stderr)
 
 if not path.isdir(file_path):
     mkdir(file_path)
@@ -46,28 +55,4 @@ with open(path.join(file_path, 'test_data_path.txt'), 'w+') as f:
 
 # Run setup
 
-setup(name='sami2py',
-      version='0.1.2',
-      url='github.com/jklenzing/sami2py',
-      author='Jeff Klenzing',
-      author_email='jeffrey.klenzing@nasa.gov',
-      description='Generate, read, and plot sami2 model runs',
-      long_description=read('README.md'),
-      packages=find_packages(),
-      classifiers=[
-          "Development Status :: 3 - Alpha",
-          "Topic :: Scientific/Engineering :: Physics",
-          "Intended Audience :: Science/Research",
-          "License :: BSD",
-          "Natural Language :: English",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.4",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Operating System :: MacOS :: MacOS X",
-      ],
-      include_package_data=True,
-      zip_safe=False,
-      test_suite='setup.sami2py_test_suite',
-      )
+setup(test_suite='setup.sami2py_test_suite')


### PR DESCRIPTION
* modernize setup: no need to have metadata in setup.py, in general we seek to minimize length of setup.py for code auditing and easier metadata parsing by moving as much as possible to setup.cfg
* specify numpy requirement
* include basic flake8/mypy template
* build sami2py.x without needing Make, relevant for Windows users in particular. Also easy to switch between compilers by just adding additional line per compiler (if ifort, etc)

In general, sami2py is now seamlessly easier to install and meets better metadata quality standard for Python with no user-apparent changes.
