### PR TITLE
expanduser path, PEP8

### DIFF
--- a/sami2py/utils.py
+++ b/sami2py/utils.py
@@ -23,6 +23,9 @@ Jeff Klenzing (JK), 1 Dec 2017, Goddard Space Flight Center (GSFC)
 -------------------------------------------------------------------------------
 """
 
+import os
+import sys
+
 
 def generate_path(tag, lon, year, day, test=False):
     """Creates a path based on run tag, date, and longitude
@@ -46,7 +49,6 @@ def generate_path(tag, lon, year, day, test=False):
     archive_path : (string)
         Complete path pointing to model archive for a given run
     """
-    from os import path
 
     if not isinstance(tag, str):
         raise TypeError
@@ -62,10 +64,10 @@ def generate_path(tag, lon, year, day, test=False):
     # a directory through set_archive_dir
     if top_directory:
         str_fmt = 'lon{lon:03d}/{year:4d}_{day:03d}/'
-        archive_path = path.join(top_directory, tag,
-                                 (str_fmt.format(lon=lon,
-                                                 year=year,
-                                                 day=day)))
+        archive_path = os.path.join(top_directory, tag,
+                                    (str_fmt.format(lon=lon,
+                                                    year=year,
+                                                    day=day)))
     else:
         raise NameError(''.join(('Archive Directory Not Specified: ',
                                  'Run sami2py.utils.set_archive_dir')))
@@ -74,6 +76,7 @@ def generate_path(tag, lon, year, day, test=False):
 
 
 def set_archive_dir(path=None, store=True):
+    # type: (str, bool) -> None
     """Set the top level directory pysat uses to look for data and reload.
 
     Parameters
@@ -83,10 +86,9 @@ def set_archive_dir(path=None, store=True):
     store : bool
         if True, store data directory for future runs
     """
-    import os
-    import sys
     import sami2py
 
+    path = os.path.expanduser(path)
     if os.path.isdir(path):
         if store:
             with open(os.path.join(sys.prefix,
@@ -125,8 +127,8 @@ def get_unformatted_data(dat_dir, var_name, reshape=False, dim0=0, dim1=0):
         unformatted data organized into a numpy array for handling in python
     """
     import numpy as np
-    from os import path
-    binary_file = open(path.join(dat_dir, var_name + 'u.dat'), 'rb')
+
+    binary_file = open(os.path.join(dat_dir, var_name + 'u.dat'), 'rb')
     float_data = np.fromfile(binary_file, dtype='float32')
     binary_file.close()
 


### PR DESCRIPTION
In general we use `os.path.expanduser()` wherever a user passes in a path to allow `~` to be used. This allows avoiding scenarios where users on laptop vs. HPC have to do the following:

* Windows laptop: c:\users\joe\data 
* Linux HPC: /home/joe/data 

where this PR allows them to  simply use  `~/data`. 

Also added Python 2 compatible [type hint](https://github.com/jklenzing/sami2py/compare/develop...scivision:expand?expand=1#diff-5f7bfbb516b6024b1c02fe6ec41a76e0R78)

Imports should almost always be at top of file, and we try to avoid "from x import y" to avoid namespace clashes. There is no advantage to hiding stdlib imports within functions in particular.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

