### PR TITLE
Update index reference for plotting routine

### DIFF
--- a/sami2py/_core_class.py
+++ b/sami2py/_core_class.py
@@ -341,7 +341,7 @@ class Model(object):
             time index for SAMI2 model results
         species : (int)
             ion species index :
-            1: H+, 2: O+, 3: NO+, 4: O2+, 5: He+, 6: N2+, 7: N+
+            0: H+, 1: O+, 2: NO+, 3: O2+, 4: He+, 5: N2+, 6: N+
         """
         import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Python indices start with 0, not 1.

## Type of change

Please delete options that are not relevant.

- Documentation Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
