### PR TITLE
Updates to setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 matrix:
   include:
+    - python: 2.7
     - python: 3.5
     - python: 3.6
     - python: 3.7
@@ -17,6 +18,8 @@ before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
+  - pip install pandas
+  - pip install xarray
   - pip install matplotlib
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,14 @@ before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  - pip install matplotlib
-
+  
 install:
   - python setup.py install
 
 before_script:
   # set up display screen
   - export DISPLAY=:99.0
-  
+
 script:
   - pytest -vs --cov=sami2py/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 matrix:
   include:
-    - python: 2.7
     - python: 3.5
     - python: 3.6
     - python: 3.7
@@ -26,11 +25,7 @@ install:
 before_script:
   # set up display screen
   - export DISPLAY=:99.0
-  - if [[ $TRAVIS_PYTHON_VERSION < "3.0" ]]; then
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
-
+  
 script:
   - pytest -vs --cov=sami2py/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  
+  - pip install matplotlib
+
 install:
   - python setup.py install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - TBD
 - API changes
+  - Remove support for python 2.7
   - Store loaded data in xarray object
   - Use consistent keyword order in run_model and Model
   - xarray (<0.12) and pandas (<0.25) are now required packages.  Upper limits enforced for Travis CI testing.  Will remove in future once python 2.7 is deprecated and things settle out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - TBD
 - API changes
-  - Remove support for python 2.7
   - Store loaded data in xarray object
   - Use consistent keyword order in run_model and Model
   - xarray (<0.12) and pandas (<0.25) are now required packages.  Upper limits enforced for Travis CI testing.  Will remove in future once python 2.7 is deprecated and things settle out.
@@ -16,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added CHANGELOG.md
   - Switched to pytest for unit testing
   - Removes python 3.4 testing from Travis
+  - Adds manual install of pandas / xarray to Travis workflow to fix setup
 
 ## [0.1.2] - 2019-07-02
 - Patch to fix loading of unformatted output files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifiers =
   Intended Audience :: Science/Research
   License :: BSD
   Natural Language :: English
-  Programming Language :: Python :: 2.7
-  Programming Language :: Python :: 3.4
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
@@ -25,7 +23,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-python_requires = >= 2.7
+python_requires = >= 3.5
 setup_requires =
   setuptools >= 38.6
   pip >= 10
@@ -34,6 +32,7 @@ zip_safe = False
 packages = find:
 install_requires =
   numpy
-  pandas<0.25 # FIXME: upper limit on pandas and xarray are just so Travis CI passes python 2.7 tests.
-  xarray<0.12
+  pandas
+  xarray
+  matplotlib
 scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
   Intended Audience :: Science/Research
   License :: BSD
   Natural Language :: English
+  Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7


### PR DESCRIPTION
# Description

Previously, artificial caps were added to `install_requires` to smooth over Travis CI tests when running for python 2.7.  This is not needed if `.travis.yml` uses pip install commands beforehand, since the correct version will be installed.  If left up to `install_requires`, the latest version is installed regardless (seems to be unique to the Travis environment).

Also, adds matplotlib as a requirement to `install_requires`, which was previously missing, and removes 3.4 from documentation.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on travis CI.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
